### PR TITLE
Fix Label in confidence-band.js to hide base-hack

### DIFF
--- a/examples/data/confidence-band.js
+++ b/examples/data/confidence-band.js
@@ -28,7 +28,7 @@ $.get(ROOT_PATH + 'data/asset/data/confidence-band.json', function (data) {
                 }
             },
             formatter: function (params) {
-                return params[2].name + '<br />' + params[2].value;
+                return params[2].name + '<br />' + ((params[2].value - base) * 100).toFixed(1) + '%';
             }
         },
         grid: {


### PR DESCRIPTION
see issues: https://github.com/apache/incubator-echarts/issues/12592

old with wrong value in label:
![grafik](https://user-images.githubusercontent.com/3290888/81845348-b8e29200-9550-11ea-8766-9d0100f906dd.png)

new one
![grafik](https://user-images.githubusercontent.com/3290888/81845370-c009a000-9550-11ea-9ee3-4735f1f61514.png)
(facked image cause I can not run this)