### PR TITLE
Update calendar-charts considering timezone issue

### DIFF
--- a/examples/data/calendar-charts.js
+++ b/examples/data/calendar-charts.js
@@ -18,7 +18,7 @@ function getVirtulData(year) {
 
 var graphData = [
     [
-        1485878400000,
+        1485964800000,
         260
     ],
     [


### PR DESCRIPTION
As original first data item of first graph will be rendered outside calendar range for any timezone later than GMT+8 and causing error, move that data to one day later