### PR TITLE
visual improvement and correction to scatter-aggregate-to-bar chart

### DIFF
--- a/examples/examples/ts/scatter-aggregate-bar.ts
+++ b/examples/examples/ts/scatter-aggregate-bar.ts
@@ -171,7 +171,10 @@ const barOption: echarts.EChartsOption = {
       data: [
         {
           value: calculateAverage(maleDeta, 0),
-          groupId: 'female'
+          groupId: 'female',
+          itemStyle: {
+            color: '#60a960'      /* green, similar to the scatter plot */
+          }
         },
         {
           value: calculateAverage(femaleData, 0),

--- a/examples/examples/ts/scatter-aggregate-bar.ts
+++ b/examples/examples/ts/scatter-aggregate-bar.ts
@@ -171,11 +171,11 @@ const barOption: echarts.EChartsOption = {
       data: [
         {
           value: calculateAverage(maleDeta, 0),
-          groupId: 'male'
+          groupId: 'female'
         },
         {
           value: calculateAverage(femaleData, 0),
-          groupId: 'female'
+          groupId: 'male'
         }
       ],
       universalTransition: {


### PR DESCRIPTION
See commit messages.

Bottom line: it's much more intuitive to **not** have the green scatter plot data points to a *blue* bar, but to a green bar instead.

Plus a minor nitpick re bar definitions (first commit).

When you wish to "preview" the visual bit: add

```
          itemStyle: {
            color: '#60a960'
          }
```

to the `barOption.series.data[0]` declaration in the live examples page on the website.

---

:+1: chart lib, BTW.