### PR TITLE
feat(site): add scroll-to-top button for improved navigation

### DIFF
--- a/layouts/basic.html
+++ b/layouts/basic.html
@@ -8,4 +8,90 @@
 }
 </script><script type="text/javascript" src="https://echarts.apache.org/zh/./js/vendors/jquery@3.7.1/dist/jquery.min.js"></script></head><!--[if lte IE 8]><body class="lower-ie"><div id="lowie-main"><img src="https://echarts.apache.org/zh/images/forie.png?_v_=20240226" alt="ie tip"></div></body><![endif]-->
 <!--[if (gt IE 8)|!(IE)]><body></body><![endif]--><noscript><div class="no-script"><strong>很抱歉，Apache ECharts 网站需要启用 JavaScript 才能正常运行。</strong></div></noscript><div id="apache-banner"><div class="txt"><p>请访问 Apache ECharts 的官网 &nbsp;</p><a id="a1" href="https://echarts.apache.org/zh/index.html">https://echarts.apache.org</a></div><a href="https://echarts.apache.org" target="_blank" onclick="logApache()" class="btn btn-main"><div>访问官网</div></a><a href="javascript:;" onclick="closeApacheBanner(true)" class="close-btn">x</a></div><div id="main"></div><script type="text/javascript" src="https://echarts.apache.org/zh/./js/vendors/bootstrap@3.3.7/js/bootstrap.min.js"></script><script type="text/javascript" src="https://echarts.apache.org/zh/js/common.js?_v_=dc080d98a9"></script><script type="text/javascript">window.ECHARTS_WWW_VENDORS_CDN_ROOT = 'https://echarts.apache.org/zh/js/vendors/';
+</script>
+<script>
+(function () {
+
+  // Remove existing button if already added
+  const existingButton = document.getElementById('scrollToTop');
+  if (existingButton) {
+    existingButton.remove();
+  }
+
+  // Add styles
+  const scrollButtonStyles = document.createElement('style');
+  scrollButtonStyles.textContent = `
+    #scrollToTop {
+      position: fixed !important;
+      bottom: 30px;
+      right: 30px;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      background: #5470c6;
+      color: #fff;
+      border: none;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.3s ease, transform 0.2s ease;
+      z-index: 9999;
+      font-size: 16px;
+    }
+
+    #scrollToTop.visible {
+      opacity: 1;
+    }
+
+    #scrollToTop:hover {
+      background: #3c66b0;
+      transform: translateY(-2px);
+    }
+
+    @media (max-width: 768px) {
+      #scrollToTop {
+        bottom: 20px;
+        right: 20px;
+        width: 40px;
+        height: 40px;
+        font-size: 14px;
+      }
+    }
+  `;
+  document.head.appendChild(scrollButtonStyles);
+
+  // Create button
+  const scrollButton = document.createElement('button');
+  scrollButton.id = 'scrollToTop';
+  scrollButton.textContent = '↑';
+  scrollButton.title = '回到顶部';
+  document.body.appendChild(scrollButton);
+
+  // Find scroll container
+  const scrollContainer = document.querySelector('.page-main');
+
+  if (!scrollContainer) return;
+
+  // Show/hide button based on scroll
+  function updateButtonVisibility() {
+    if (scrollContainer.scrollTop > 300) {
+      scrollButton.classList.add('visible');
+    } else {
+      scrollButton.classList.remove('visible');
+    }
+  }
+
+  // Scroll to top smoothly
+  function scrollToTop() {
+    scrollContainer.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }
+
+  scrollContainer.addEventListener('scroll', updateButtonVisibility);
+  scrollButton.addEventListener('click', scrollToTop);
+
+  updateButtonVisibility();
+
+})();
 </script></html>

--- a/layouts/doc.html
+++ b/layouts/doc.html
@@ -14,4 +14,90 @@
 </script><script src="https://echarts.apache.org/zh/./js/vendors/vue@2.6.14/vue.min.js"></script><script src="https://echarts.apache.org/zh/./js/vendors/element-ui@2.15.14/index.js"></script><script src="https://echarts.apache.org/zh/./js/vendors/codemirror@5.56.0/codemirror.min.js"></script><script src="https://echarts.apache.org/zh/./js/vendors/codemirror@5.56.0/mode/javascript/javascript.js"></script><script src="https://echarts.apache.org/zh/./js/vendors/js-beautify@1.11.0/beautifier.min.js"></script><script src="https://echarts.apache.org/zh/js/doc-bundle.js?_v_=25901f70dd"></script><script type="text/javascript">document.getElementById('nav-doc').className = 'active';
 window.EC_WWW_CDN_PAY_ROOT = 'https://echarts.apache.org';
 </script><script type="text/javascript">window.globalArgsExtra.version = '39b98a9197';
-echartsDoc.init('#ec-doc-main', window.globalArgsExtra);</script></html>
+echartsDoc.init('#ec-doc-main', window.globalArgsExtra);</script>
+<script>
+(function () {
+
+  // Remove existing button if already added
+  const existingButton = document.getElementById('scrollToTop');
+  if (existingButton) {
+    existingButton.remove();
+  }
+
+  // Add styles
+  const scrollButtonStyles = document.createElement('style');
+  scrollButtonStyles.textContent = `
+    #scrollToTop {
+      position: fixed !important;
+      bottom: 30px;
+      right: 30px;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      background: #5470c6;
+      color: #fff;
+      border: none;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.3s ease, transform 0.2s ease;
+      z-index: 9999;
+      font-size: 16px;
+    }
+
+    #scrollToTop.visible {
+      opacity: 1;
+    }
+
+    #scrollToTop:hover {
+      background: #3c66b0;
+      transform: translateY(-2px);
+    }
+
+    @media (max-width: 768px) {
+      #scrollToTop {
+        bottom: 20px;
+        right: 20px;
+        width: 40px;
+        height: 40px;
+        font-size: 14px;
+      }
+    }
+  `;
+  document.head.appendChild(scrollButtonStyles);
+
+  // Create button
+  const scrollButton = document.createElement('button');
+  scrollButton.id = 'scrollToTop';
+  scrollButton.textContent = '↑';
+  scrollButton.title = '回到顶部';
+  document.body.appendChild(scrollButton);
+
+  // Find scroll container
+  const scrollContainer = document.querySelector('.page-main');
+
+  if (!scrollContainer) return;
+
+  // Show/hide button based on scroll
+  function updateButtonVisibility() {
+    if (scrollContainer.scrollTop > 300) {
+      scrollButton.classList.add('visible');
+    } else {
+      scrollButton.classList.remove('visible');
+    }
+  }
+
+  // Scroll to top smoothly
+  function scrollToTop() {
+    scrollContainer.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }
+
+  scrollContainer.addEventListener('scroll', updateButtonVisibility);
+  scrollButton.addEventListener('click', scrollToTop);
+
+  updateButtonVisibility();
+
+})();
+</script></html>

--- a/layouts/example.html
+++ b/layouts/example.html
@@ -15,4 +15,90 @@
 window.EC_WWW_CDN_PAY_ROOT = 'https://echarts.apache.org';
 </script><script type="text/javascript">window.globalArgsExtra.version = '1769113551514';
 window.globalArgsExtra.cdnRoot = EC_WWW_CDN_PAY_ROOT + '/examples';
-echartsExample.init('#ec-example-main', window.globalArgsExtra);</script></html>
+echartsExample.init('#ec-example-main', window.globalArgsExtra);</script>
+<script>
+(function () {
+
+  // Remove existing button if already added
+  const existingButton = document.getElementById('scrollToTop');
+  if (existingButton) {
+    existingButton.remove();
+  }
+
+  // Add styles
+  const scrollButtonStyles = document.createElement('style');
+  scrollButtonStyles.textContent = `
+    #scrollToTop {
+      position: fixed !important;
+      bottom: 30px;
+      right: 30px;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      background: #5470c6;
+      color: #fff;
+      border: none;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.3s ease, transform 0.2s ease;
+      z-index: 9999;
+      font-size: 16px;
+    }
+
+    #scrollToTop.visible {
+      opacity: 1;
+    }
+
+    #scrollToTop:hover {
+      background: #3c66b0;
+      transform: translateY(-2px);
+    }
+
+    @media (max-width: 768px) {
+      #scrollToTop {
+        bottom: 20px;
+        right: 20px;
+        width: 40px;
+        height: 40px;
+        font-size: 14px;
+      }
+    }
+  `;
+  document.head.appendChild(scrollButtonStyles);
+
+  // Create button
+  const scrollButton = document.createElement('button');
+  scrollButton.id = 'scrollToTop';
+  scrollButton.textContent = '↑';
+  scrollButton.title = '回到顶部';
+  document.body.appendChild(scrollButton);
+
+  // Find scroll container
+  const scrollContainer = document.querySelector('.page-main');
+
+  if (!scrollContainer) return;
+
+  // Show/hide button based on scroll
+  function updateButtonVisibility() {
+    if (scrollContainer.scrollTop > 300) {
+      scrollButton.classList.add('visible');
+    } else {
+      scrollButton.classList.remove('visible');
+    }
+  }
+
+  // Scroll to top smoothly
+  function scrollToTop() {
+    scrollContainer.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }
+
+  scrollContainer.addEventListener('scroll', updateButtonVisibility);
+  scrollButton.addEventListener('click', scrollToTop);
+
+  updateButtonVisibility();
+
+})();
+</script></html>


### PR DESCRIPTION
## Summary
This PR adds a scroll-to-top button to improve navigation on long documentation and example pages.

## Details
- Displays button after user scrolls down
- Enables smooth scrolling back to top  
- Integrated across layout templates (basic, doc, example)

## Motivation
Documentation pages can become lengthy, requiring excessive manual scrolling.
This enhancement improves usability and user experience without affecting existing layout structure.

## Testing
Tested locally across affected layouts to ensure:
- Button visibility triggers correctly on scroll
- Smooth scrolling behavior works as expected
- No layout breakage introduced

**Fixes:** apache/echarts#21516
